### PR TITLE
feat: ✨ add Display settings tab with stacked query results option

### DIFF
--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -270,6 +270,71 @@
         :message="runningText"
         v-if="running"
       />
+      <template v-else-if="queryResultsLayout === 'stacked' && results && results.length > 0">
+        <div class="stacked-results">
+          <div
+            v-for="(r, idx) in results"
+            :key="idx"
+            class="stacked-result-block"
+          >
+            <div class="stacked-result-header">
+              <span class="stacked-result-label">
+                Result {{ idx + 1 }}
+                <span v-if="r.rows && r.rows.length > 0">· {{ r.rows.length }} {{ r.rows.length === 1 ? 'row' : 'rows' }}</span>
+                <span v-else-if="r.affectedRows">· {{ r.affectedRows }} rows affected</span>
+              </span>
+              <x-button
+                v-if="r.rows && r.rows.length > 0"
+                class="btn btn-flat btn-icon stacked-download-btn"
+                menu
+              >
+                <i class="material-icons">download</i>
+                <i class="material-icons">arrow_drop_down</i>
+                <x-menu>
+                  <x-menuitem @click.prevent="stackedDownload(idx, 'csv')">
+                    <x-label>Download as CSV</x-label>
+                  </x-menuitem>
+                  <x-menuitem @click.prevent="stackedDownload(idx, 'xlsx')">
+                    <x-label>Download as Excel</x-label>
+                  </x-menuitem>
+                  <x-menuitem @click.prevent="stackedDownload(idx, 'json')">
+                    <x-label>Download as JSON</x-label>
+                  </x-menuitem>
+                  <x-menuitem @click.prevent="stackedDownload(idx, 'md')">
+                    <x-label>Download as Markdown</x-label>
+                  </x-menuitem>
+                  <hr>
+                  <x-menuitem @click.prevent="stackedClipboard(idx)">
+                    <x-label>Copy to Clipboard (TSV / Excel)</x-label>
+                  </x-menuitem>
+                  <x-menuitem @click.prevent="stackedClipboard(idx, 'json')">
+                    <x-label>Copy to Clipboard (JSON)</x-label>
+                  </x-menuitem>
+                  <x-menuitem @click.prevent="stackedClipboard(idx, 'md')">
+                    <x-label>Copy to Clipboard (Markdown)</x-label>
+                  </x-menuitem>
+                </x-menu>
+              </x-button>
+            </div>
+            <result-table
+              v-if="r.rows && r.rows.length > 0"
+              :ref="'stackedTable_' + idx"
+              :active="active"
+              :table-height="200"
+              :result="r"
+              :query="query"
+              :tab="tab"
+              :binary-encoding="$bksConfig.ui.general.binaryEncoding"
+            />
+            <div class="message" v-else>
+              <div class="alert alert-info">
+                <i class="material-icons-outlined">info</i>
+                <span>No results. {{ r.affectedRows || 0 }} rows affected.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </template>
       <result-table
         ref="table"
         v-else-if="showResultTable"
@@ -317,6 +382,7 @@
         v-model="selectedResult"
         :results="results"
         :running="running"
+        :layout="queryResultsLayout"
         @download="download"
         @clipboard="clipboard"
         @clipboardJson="clipboardJson"
@@ -617,6 +683,7 @@
         'userKeymap': 'settings/userKeymap',
         'autocompleteUppercaseKeywords': 'settings/autocompleteUppercaseKeywords',
         'autoQuoteIdentifiers': 'settings/autoQuoteIdentifiers',
+        'queryResultsLayout': 'settings/queryResultsLayout',
       }),
       ...mapState(['usedConfig', 'connectionType', 'database', 'tables', 'storeInitialized', 'connection']),
       ...mapState('data/queries', {'savedQueries': 'items'}),
@@ -1142,6 +1209,16 @@
         // eslint-disable-next-line
         // @ts-ignore
         const data = this.$refs.table.clipboard('md')
+      },
+      stackedDownload(idx, format) {
+        const ref = this.$refs[`stackedTable_${idx}`]
+        const table = Array.isArray(ref) ? ref[0] : ref
+        if (table) table.download(format)
+      },
+      stackedClipboard(idx, format = null) {
+        const ref = this.$refs[`stackedTable_${idx}`]
+        const table = Array.isArray(ref) ? ref[0] : ref
+        if (table) table.clipboard(format)
       },
       selectEditor() {
         this.focusElement = 'text-editor'
@@ -1671,6 +1748,39 @@
 <style lang="scss" scoped>
   @use "sass:color";
   @import '../assets/styles/app/_variables';
+
+  .stacked-results {
+    overflow-y: auto;
+    height: 100%;
+
+    .stacked-result-block {
+      border-bottom: 1px solid var(--border-color);
+
+      &:last-child {
+        border-bottom: none;
+      }
+    }
+
+    .stacked-result-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.2rem 0.4rem 0.2rem 0.75rem;
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: var(--text-dark);
+      background: var(--bg-secondary, var(--query-editor-bg));
+      border-bottom: 1px solid var(--border-color);
+      position: sticky;
+      top: 0;
+      z-index: 1;
+    }
+
+    .stacked-download-btn {
+      font-size: 0.75rem;
+      padding: 0.1rem 0.3rem;
+    }
+  }
 
   label[for="commit-mode"] {
     color: var(--text);

--- a/apps/studio/src/components/editor/QueryEditorStatusBar.vue
+++ b/apps/studio/src/components/editor/QueryEditorStatusBar.vue
@@ -10,7 +10,7 @@
         v-hotkey="keymap"
       >
         <span
-          v-show="results?.length > 1"
+          v-show="results?.length > 1 && layout !== 'stacked'"
           class="statusbar-item result-selector"
           :title="'Results'"
         >
@@ -77,6 +77,7 @@
     </template>
     <span class="expand" />
     <x-button
+      v-if="layout !== 'stacked'"
       class="btn btn-flat btn-icon end"
       :disabled="results?.length === 0"
       menu
@@ -189,7 +190,7 @@ const shortEnglishHumanizer = humanizeDuration.humanizer({
 });
 
 export default {
-  props: ['results', 'running', 'value', 'executeTime', 'wrapText', 'active', 'elapsedTime'],
+  props: ['results', 'running', 'value', 'executeTime', 'wrapText', 'active', 'elapsedTime', 'layout'],
   components: { Statusbar },
   data() {
     return {

--- a/apps/studio/src/components/settings/DisplaySettings.vue
+++ b/apps/studio/src/components/settings/DisplaySettings.vue
@@ -1,0 +1,97 @@
+<template>
+  <div class="display-settings">
+    <div class="setting-section-title">Query Results</div>
+
+    <div class="form-group">
+      <label>Results Layout</label>
+      <div class="radio-group">
+        <label class="radio-option">
+          <input
+            type="radio"
+            value="tabs"
+            :checked="queryResultsLayout === 'tabs'"
+            @change="saveLayout('tabs')"
+          />
+          <span>Tabs</span>
+          <small class="help text-muted">Show one result at a time. Use the dropdown in the status bar to switch between results.</small>
+        </label>
+        <label class="radio-option">
+          <input
+            type="radio"
+            value="stacked"
+            :checked="queryResultsLayout === 'stacked'"
+            @change="saveLayout('stacked')"
+          />
+          <span>Stacked</span>
+          <small class="help text-muted">Display all result sets vertically, one table below the other.</small>
+        </label>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { mapGetters } from 'vuex'
+
+export default Vue.extend({
+  computed: {
+    ...mapGetters({
+      queryResultsLayout: 'settings/queryResultsLayout',
+    }),
+  },
+  methods: {
+    async saveLayout(value: string) {
+      await this.$store.dispatch('settings/save', {
+        key: 'queryResultsLayout',
+        value,
+      })
+    },
+  },
+})
+</script>
+
+<style lang="scss" scoped>
+.setting-section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.radio-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.radio-option {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto auto;
+  column-gap: 0.5rem;
+  row-gap: 0.1rem;
+  cursor: pointer;
+
+  input[type="radio"] {
+    grid-row: 1;
+    grid-column: 1;
+    margin-top: 0.2rem;
+  }
+
+  span {
+    grid-row: 1;
+    grid-column: 2;
+    font-weight: 500;
+  }
+
+  .help {
+    grid-row: 2;
+    grid-column: 2;
+    display: block;
+    font-size: 0.78rem;
+    line-height: 1.4;
+  }
+}
+</style>

--- a/apps/studio/src/components/settings/SettingsModal.vue
+++ b/apps/studio/src/components/settings/SettingsModal.vue
@@ -29,6 +29,7 @@
           </div>
 
           <div class="settings-body">
+            <display-settings v-if="currentTab === 'display'" />
             <azure-vault-settings v-if="currentTab === 'azure'" />
             <formatting-settings v-if="currentTab === 'formatting'" />
           </div>
@@ -42,13 +43,15 @@
 import Vue from 'vue'
 import AzureVaultSettings from './AzureVaultSettings.vue'
 import FormattingSettings from './FormattingSettings.vue'
+import DisplaySettings from './DisplaySettings.vue'
 
 export default Vue.extend({
-  components: { AzureVaultSettings, FormattingSettings },
+  components: { AzureVaultSettings, FormattingSettings, DisplaySettings },
   data() {
     return {
-      currentTab: 'formatting' as string,
+      currentTab: 'display' as string,
       tabs: [
+        { id: 'display', label: 'Display' },
         { id: 'formatting', label: 'Formatting' },
         { id: 'azure', label: 'Azure Key Vault' },
       ],

--- a/apps/studio/src/store/modules/settings/SettingStoreModule.ts
+++ b/apps/studio/src/store/modules/settings/SettingStoreModule.ts
@@ -121,6 +121,10 @@ const SettingStoreModule: Module<State, any> = {
       if (!setting) return false;
       return setting.value === true;
     },
+    queryResultsLayout(state) {
+      const value = state.settings.queryResultsLayout?.value as string;
+      return value === 'stacked' ? 'stacked' : 'tabs';
+    },
   }
 }
 


### PR DESCRIPTION
## Summary                                                                                                                                                                             
                                                            
  - Adds a **Display** tab to the Settings modal (first tab, opens by default)                                                                                                           
  - New "Results Layout" setting with two options:
    - **Tabs** (default) — existing behaviour, one result at a time with the status bar dropdown to switch                                                                               
    - **Stacked** — all result sets rendered vertically as separate tables after a multi-query run
  - Each stacked result block has its own Download / Copy to Clipboard menu scoped to that result
  - The global Download button in the status bar is hidden when Stacked mode is active
  - Setting is persisted via the existing `appdb/setting` store (`queryResultsLayout` key)