### PR TITLE
feat: ✨ add user-configurable accent colour to Display settings

### DIFF
--- a/apps/studio/src/App.vue
+++ b/apps/studio/src/App.vue
@@ -125,6 +125,7 @@ export default Vue.extend({
       'isTrial': 'isTrial',
       'isUltimate': 'isUltimate',
       'themeValue': 'settings/themeValue',
+      'accentColor': 'settings/accentColor',
     }),
     editorFontSize() {
       return this.$store.state.settings?.settings?.editorFontSize?.value || 14
@@ -137,6 +138,16 @@ export default Vue.extend({
     themeValue() {
       document.body.className = `theme-${this.themeValue}`
       this.trigger(AppEvent.changedTheme, this.themeValue)
+      if (this.accentColor) {
+        document.body.style.setProperty('--theme-primary', this.accentColor)
+      }
+    },
+    accentColor(val) {
+      if (val) {
+        document.body.style.setProperty('--theme-primary', val)
+      } else {
+        document.body.style.removeProperty('--theme-primary')
+      }
     },
     status(curr, prev) {
       this.$store.dispatch('updateWindowTitle')
@@ -173,6 +184,9 @@ export default Vue.extend({
     })
     if (this.themeValue) {
       document.body.className = `theme-${this.themeValue}`
+    }
+    if (this.accentColor) {
+      document.body.style.setProperty('--theme-primary', this.accentColor)
     }
 
     if (this.url) {

--- a/apps/studio/src/assets/styles/app/_layout.scss
+++ b/apps/studio/src/assets/styles/app/_layout.scss
@@ -110,9 +110,9 @@ x-buttons > x-button[menu].btn {
 
 .btn-brand {
   color: #181818;
-  background: $theme-primary;
+  background: var(--theme-primary);
   &:hover, &:focus {
-    background: $theme-primary;
+    background: var(--theme-primary);
     color: #000;
   }
 }
@@ -311,7 +311,7 @@ label {
   }
 }
 
-input, select, textarea, .bk-form-input {
+input:not([type=checkbox]):not([type=radio]), select, textarea, .bk-form-input {
   font-family: $font-family;
   font-size: $base-font-size;
   @include form-control;
@@ -319,6 +319,7 @@ input, select, textarea, .bk-form-input {
     border-color: $input-highlight;
   }
 }
+
 .input-group {
   position: relative;
   display: flex;
@@ -429,8 +430,7 @@ input[type="checkbox"] {
   &:active,
   &:checked,
   &:checked:active {
-    background: $theme-base;
-    color: $theme-bg;
+    background: var(--theme-primary);
     box-shadow: none;
     outline: none;
   }
@@ -465,12 +465,11 @@ input[type="radio"] {
   border: 0;
   margin-top: -1px;
   margin-right: $gutter-h;
-  border-radius: 5px;
+  border-radius: 50%;
   transition: background 0.2s ease-in-out;
   cursor: pointer;
-  &:checked{
-    background: color.adjust($theme-primary, $lightness: -10%);
-    color: rgba(black, 0.87);
+  &:checked {
+    background: var(--theme-primary);
     box-shadow: none;
   }
 }
@@ -567,7 +566,7 @@ input[type=file] {
 }
 .item-icon {
   font-size: 12px;
-  color: color.adjust($theme-primary, $lightness: -15%);
+  color: var(--theme-primary);
   &.schema-icon {
     color: $text-lighter;
   }

--- a/apps/studio/src/assets/styles/app/connection-interface.scss
+++ b/apps/studio/src/assets/styles/app/connection-interface.scss
@@ -112,7 +112,7 @@
   .pitch {
     text-align: center;
     a {
-      color: $theme-primary;
+      color: var(--theme-primary);
       &:hover {
         text-decoration: underline;
       }
@@ -181,7 +181,7 @@
   }
   &.enabled {
     i {
-      color: $theme-primary;
+      color: var(--theme-primary);
     }
   }
   x-switch {

--- a/apps/studio/src/assets/styles/app/export-modal.scss
+++ b/apps/studio/src/assets/styles/app/export-modal.scss
@@ -14,7 +14,7 @@
     .dialog-c-link {
         margin-left: $gutter-w;
         font-size: 0.8rem;
-        color:$theme-primary;
+        color: var(--theme-primary);
         text-decoration: underline;
         &:hover {
 

--- a/apps/studio/src/assets/styles/app/sidebar/sidebar.scss
+++ b/apps/studio/src/assets/styles/app/sidebar/sidebar.scss
@@ -187,7 +187,7 @@
           &.active {
             background: rgba($theme-base, 0.1);
             .material-icons {
-              color: $theme-primary;
+              color: var(--theme-primary);
             }
           }
 
@@ -261,7 +261,7 @@
     border-radius: $list-heading-height;
     background: $border-color;
     &.active {
-      color: $theme-primary;
+      color: var(--theme-primary);
     }
   }
   .actions {
@@ -432,7 +432,7 @@
         &.pinned {
           display: inline-flex;
           i.bk-pin {
-            color: $theme-primary;
+            color: var(--theme-primary);
           }
           i.material-icons {
             display:none;

--- a/apps/studio/src/assets/styles/app/tabs/table-properties.scss
+++ b/apps/studio/src/assets/styles/app/tabs/table-properties.scss
@@ -90,8 +90,8 @@ $cell-success:           $row-add;
         box-shadow: inset 0 -2px rgba($theme-base, 0.2);
       }
       &.active {
-        color: $theme-primary;
-        box-shadow: inset 0 -2px $theme-primary;
+        color: var(--theme-primary);
+        box-shadow: inset 0 -2px var(--theme-primary);
       }
     }
   }

--- a/apps/studio/src/assets/styles/app/tabs/tabletable.scss
+++ b/apps/studio/src/assets/styles/app/tabs/tabletable.scss
@@ -20,7 +20,7 @@
         }
         &:hover {
           span.material-icons {
-            color: $theme-primary
+            color: var(--theme-primary)
           }
         }
       }

--- a/apps/studio/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/studio/src/assets/styles/app/vendor/tabulator.scss
@@ -111,7 +111,7 @@ $columnResizeGuideColor:      color.mix($query-editor-bg, $theme-base, 80%);
     }
     &.row-moved {
       .tabulator-cell {
-        background: rgba($theme-primary, 0.08) !important;
+        background: color-mix(in srgb, var(--theme-primary) 8%, transparent) !important;
       }
     }
   }
@@ -537,7 +537,7 @@ $columnResizeGuideColor:      color.mix($query-editor-bg, $theme-base, 80%);
           content: 'vpn_key';
           font-family: 'Material Icons';
           font-size: $font-size;
-          color: $theme-primary;
+          color: var(--theme-primary);
           padding-left: $foreign-key-width - $font-size;
           display: inline-flex;
           align-items: center;
@@ -810,11 +810,11 @@ $columnResizeGuideColor:      color.mix($query-editor-bg, $theme-base, 80%);
 
 .tabulator .tabulator-tableholder .tabulator-range-overlay {
   .tabulator-range, .tabulator-range-cell-active {
-    border-color: color.adjust($theme-primary, $lightness: -20%);
+    border-color: var(--theme-primary);
     border-width: 1px;
   }
   .tabulator-range.tabulator-range-active::after {
-    background-color: color.adjust($theme-primary, $lightness: -20%);
+    background-color: var(--theme-primary);
   }
   .tabulator-range.copied {
     border-style: dashed;

--- a/apps/studio/src/assets/styles/themes/light/theme.scss
+++ b/apps/studio/src/assets/styles/themes/light/theme.scss
@@ -200,7 +200,7 @@ x-buttons {
   }
 }
 .item-icon {
-  color: color.adjust($theme-primary, $lightness: -6%);
+  color: var(--theme-primary);
 }
 
 // Editor

--- a/apps/studio/src/assets/styles/themes/solarized-light/theme.scss
+++ b/apps/studio/src/assets/styles/themes/solarized-light/theme.scss
@@ -201,7 +201,7 @@ x-buttons {
   }
 }
 .item-icon {
-  color: $theme-primary;
+  color: var(--theme-primary);
 }
 
 // Editor

--- a/apps/studio/src/components/settings/AzureVaultSettings.vue
+++ b/apps/studio/src/components/settings/AzureVaultSettings.vue
@@ -5,7 +5,6 @@
     <div class="form-group">
       <label class="checkbox-group" for="vaultEnabled">
         <input
-          class="form-control"
           id="vaultEnabled"
           type="checkbox"
           v-model="form.enabled"

--- a/apps/studio/src/components/settings/DisplaySettings.vue
+++ b/apps/studio/src/components/settings/DisplaySettings.vue
@@ -27,6 +27,47 @@
         </label>
       </div>
     </div>
+
+    <div class="setting-section-title">Accent Color</div>
+
+    <div class="form-group">
+      <label>Color</label>
+      <div class="accent-color-row">
+        <input
+          type="color"
+          class="color-input"
+          :value="accentColorValue"
+          @input="onColorInput"
+          @change="onColorChange"
+        />
+        <span class="color-hex">{{ accentColorValue }}</span>
+        <button
+          class="btn btn-flat reset-btn"
+          :disabled="!accentColor"
+          @click="resetAccentColor"
+        >
+          Reset
+        </button>
+      </div>
+      <small class="help text-muted">
+        Overrides the theme's accent color. Used for active tab indicators, highlights, and other accents.
+      </small>
+    </div>
+
+    <div class="form-group">
+      <label>Presets</label>
+      <div class="color-presets">
+        <button
+          v-for="preset in colorPresets"
+          :key="preset.hex"
+          class="color-swatch"
+          :class="{ active: accentColorValue === preset.hex }"
+          :style="{ background: preset.hex }"
+          :title="preset.label"
+          @click="applyPreset(preset.hex)"
+        />
+      </div>
+    </div>
   </div>
 </template>
 
@@ -34,11 +75,31 @@
 import Vue from 'vue'
 import { mapGetters } from 'vuex'
 
+const THEME_DEFAULT = '#fad83b'
+
 export default Vue.extend({
+  data() {
+    return {
+      pendingColor: null as string | null,
+      colorPresets: [
+        { label: 'Yellow (default)', hex: '#fad83b' },
+        { label: 'Blue',   hex: '#5881D8' },
+        { label: 'Cyan',   hex: '#4ad0ff' },
+        { label: 'Green',  hex: '#3ddc84' },
+        { label: 'Red',    hex: '#ff4757' },
+        { label: 'Purple', hex: '#a855f7' },
+        { label: 'Orange', hex: '#ff6b2b' },
+      ],
+    }
+  },
   computed: {
     ...mapGetters({
       queryResultsLayout: 'settings/queryResultsLayout',
+      accentColor: 'settings/accentColor',
     }),
+    accentColorValue(): string {
+      return this.pendingColor ?? this.accentColor ?? THEME_DEFAULT
+    },
   },
   methods: {
     async saveLayout(value: string) {
@@ -46,6 +107,24 @@ export default Vue.extend({
         key: 'queryResultsLayout',
         value,
       })
+    },
+    onColorInput(e: Event) {
+      const value = (e.target as HTMLInputElement).value
+      this.pendingColor = value
+      document.body.style.setProperty('--theme-primary', value)
+    },
+    async onColorChange(e: Event) {
+      const value = (e.target as HTMLInputElement).value
+      this.pendingColor = null
+      await this.$store.dispatch('settings/save', { key: 'accentColor', value })
+    },
+    async applyPreset(hex: string) {
+      this.pendingColor = null
+      await this.$store.dispatch('settings/save', { key: 'accentColor', value: hex })
+    },
+    async resetAccentColor() {
+      this.pendingColor = null
+      await this.$store.dispatch('settings/save', { key: 'accentColor', value: null })
     },
   },
 })
@@ -58,6 +137,10 @@ export default Vue.extend({
   margin-bottom: 1rem;
   padding-bottom: 0.5rem;
   border-bottom: 1px solid var(--border-color);
+
+  & + .form-group {
+    margin-top: 0.75rem;
+  }
 }
 
 .radio-group {
@@ -89,9 +172,82 @@ export default Vue.extend({
   .help {
     grid-row: 2;
     grid-column: 2;
+  }
+}
+
+.accent-color-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.color-input {
+  width: 2.4rem;
+  height: 2.4rem;
+  padding: 0.1rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: none;
+  cursor: pointer;
+}
+
+.color-hex {
+  font-size: 0.85rem;
+  font-family: monospace;
+  color: var(--text);
+  min-width: 5rem;
+}
+
+.reset-btn {
+  font-size: 0.8rem;
+  padding: 0.2rem 0.6rem;
+  margin-left: auto;
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+}
+
+.color-presets {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.color-swatch {
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  cursor: pointer;
+  transition: transform 0.1s, border-color 0.1s;
+
+  &:hover {
+    transform: scale(1.15);
+  }
+
+  &.active {
+    border-color: var(--text);
+  }
+}
+
+.help {
+  display: block;
+  margin-top: 0.3rem;
+  font-size: 0.78rem;
+  line-height: 1.4;
+  color: var(--text-light);
+}
+
+.form-group {
+  margin-bottom: 1.25rem;
+
+  label {
     display: block;
-    font-size: 0.78rem;
-    line-height: 1.4;
+    font-weight: 500;
+    margin-bottom: 0.4rem;
+    font-size: 0.875rem;
   }
 }
 </style>

--- a/apps/studio/src/components/settings/FormattingSettings.vue
+++ b/apps/studio/src/components/settings/FormattingSettings.vue
@@ -22,7 +22,6 @@
       <label class="checkbox-group" for="autoQuote">
         <input
           id="autoQuote"
-          class="form-control"
           type="checkbox"
           :checked="autoQuoteIdentifiers"
           @change="saveAutoQuote($event.target.checked)"

--- a/apps/studio/src/components/settings/SettingsModal.vue
+++ b/apps/studio/src/components/settings/SettingsModal.vue
@@ -5,7 +5,7 @@
       class="vue-dialog beekeeper-modal app-settings-modal"
       height="auto"
       :scrollable="true"
-      :max-height="600"
+      :max-height="750"
     >
       <div v-kbd-trap="true">
         <div class="dialog-content">
@@ -113,7 +113,7 @@ export default Vue.extend({
 
 .settings-body {
   padding: 1rem 0 0.5rem;
-  max-height: 480px;
+  max-height: 630px;
   overflow-y: auto;
 }
 </style>

--- a/apps/studio/src/store/modules/settings/SettingStoreModule.ts
+++ b/apps/studio/src/store/modules/settings/SettingStoreModule.ts
@@ -125,6 +125,10 @@ const SettingStoreModule: Module<State, any> = {
       const value = state.settings.queryResultsLayout?.value as string;
       return value === 'stacked' ? 'stacked' : 'tabs';
     },
+    accentColor(state) {
+      const value = state.settings.accentColor?.value as string;
+      return value || null;
+    },
   }
 }
 


### PR DESCRIPTION
## Summary                                                                                                                                                                             
                                                                                                                                                                                       
  - Adds an **Accent Color** section to the Display settings tab                                                                                                                         
  - Users can pick any color via a native color picker or choose from 7 presets (Yellow, Blue, Cyan, Green, Red, Purple, Orange)
  - A **Reset** button restores the theme's default accent color                                                                                                                         
  - Color is applied instantly as a live preview while dragging the picker, and persisted to the app database on commit
  - Switching themes preserves the custom accent color